### PR TITLE
Fix Space key and remove allocations in frame loop

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,12 @@ let beatFactor2;
 let beatFactor3;
 let beatFactor4;
 let elapsedTime;
+const localVector3 = new THREE.Vector3();
+const localVector31 = new THREE.Vector3();
+const localColor = new THREE.Color();
+const localColor1 = new THREE.Color();
+const localColor2 = new THREE.Color();
+const localColor3 = new THREE.Color();
 
 export default (e) => {
   const app = useApp();
@@ -289,7 +295,7 @@ export default (e) => {
     // currentTime: 100.2,
   };
   document.body.onkeyup = (e) => {
-    if (e.code === 'Space') {
+    if (e.code === 'KeyM') {
       const audio = getAudio({ createOnCall: false });
       if (audio.paused !== undefined) {
         if (audio.paused) {
@@ -329,14 +335,14 @@ export default (e) => {
         0.3 + moodChanger / 10 + (beatFactor2 ? beatFactor2 / 40 : 0),
         Math.abs(0.8 - moodChanger) + (beatFactor1 ? beatFactor1 / 30 : 0),
       ];
-      neonClubCyberLinesMaterial.uniforms.uMood.value = new THREE.Vector3(
-        ...moodChangerColor
+      neonClubCyberLinesMaterial.uniforms.uMood.value = localVector3.fromArray(
+        moodChangerColor
       );
-      neonClubEmissiveMaterial.uniforms.uMood.value = new THREE.Vector3(
-        ...moodChangerColor
+      neonClubEmissiveMaterial.uniforms.uMood.value = localVector31.fromArray(
+        moodChangerColor
       );
       if (beatFactor1) {
-        cloudMaterial1.color = new THREE.Color(
+        localColor.setRGB(
           (moodChangerColor[0] + beatFactor1 / 30) / 5,
           (moodChangerColor[1] + beatFactor1 / 22) / 5,
           (moodChangerColor[2] + beatFactor1 / 30) / 5
@@ -345,27 +351,31 @@ export default (e) => {
         neonClubCyberLinesMaterial.uniforms.uBeat1.value = beatFactor1;
         neonClubCyberLinesMaterial.uniforms.uBeat2.value = beatFactor3;
         sphere.material.uniforms.uBeat.value = beatFactor3;
+        // cloudMaterial1.color = localColor;
       }
       if (beatFactor2) {
-        cloudMaterial2.color = new THREE.Color(
+        localColor1.setRGB(
           (moodChangerColor[1] + beatFactor2 / 22) / 5,
           (moodChangerColor[0] + beatFactor2 / 30) / 5,
           (moodChangerColor[2] + beatFactor2 / 30) / 5
         );
+        // cloudMaterial2.color = localColor1;
       }
       if (beatFactor3) {
-        cloudMaterial3.color = new THREE.Color(
+        localColor2.setRGB(
           (moodChangerColor[0] - beatFactor3 / 30) / 5,
           (moodChangerColor[1] + beatFactor3 / 25) / 5,
           (moodChangerColor[2] + beatFactor3 / 30) / 5
         );
+        // cloudMaterial3.color = localColor2;
       }
       if (beatFactor4) {
-        cloudMaterial4.color = new THREE.Color(
+        localColor3.setRGB(
           (moodChangerColor[0] - beatFactor4 / 30) / 5,
           (moodChangerColor[1] + beatFactor4 / 24) / 5,
           (moodChangerColor[2] + beatFactor4 / 32) / 5
         );
+        // cloudMaterial4.color = localColor3;
       }
     }
     // shaking the scene with beat


### PR DESCRIPTION
Fix for https://github.com/webaverse/app/issues/3479

I changed the key to activate music from `Space` to `m`.
While running it in the browser I've got console errors on each tick from color allocations.
I optimized these by exchanging allocations to locals in the frame loop.