### PR TITLE
Patriboz/fix audio doesn't get destroyed on switching scene #3570

### DIFF
--- a/audio/index.js
+++ b/audio/index.js
@@ -29,6 +29,18 @@ const setupAudioContext = (audio) => {
   }
 }
 
+const removeAudioContext = () => {
+  if(audioContextHasBeenInitialized) {
+    audioContext.suspend();
+    audioContext.close();
+    source = null;
+    volumeControl = null;
+    analyzer = null;
+    audioContext = null;
+    audioContextHasBeenInitialized = false;
+  }
+};
+
 export const createAudio = ({ source, volume, autoPlay, currentTime }) => {
   if (!audioHasBeenCreated) {
     audio = new Audio()
@@ -39,6 +51,7 @@ export const createAudio = ({ source, volume, autoPlay, currentTime }) => {
     // "https://res.cloudinary.com/musixdevelop/video/upload/track-audios/DontLetMeDown.mp3"
     // audio.src = '/Ping 2.mp3'
     // audio.src = '/vocals.wav'
+    console.log(source);
     audio.src = source
     audio.currentTime = currentTime || 0
     audio.volume = volume || 1
@@ -51,6 +64,16 @@ export const createAudio = ({ source, volume, autoPlay, currentTime }) => {
     audioHasBeenCreated = true
   }
 }
+
+export const destroyAudio = () => {
+  if(audioHasBeenCreated) {
+    audio.pause();
+    removeAudioContext();
+    document.body.removeChild(audio);
+    audio = {};
+    audioHasBeenCreated = false;
+  }
+};
 
 export const getAudioFrequenciesByRange = ({
   frequencyData,
@@ -154,7 +177,9 @@ export const logMood = () => {
 }
 
 export const getAudio = ({ createOnCall }) => {
+  console.log(createOnCall, audio);
   if (createOnCall && !audio) {
+    console.log('create');
     createAudio()
   }
   return audio

--- a/audio/index.js
+++ b/audio/index.js
@@ -51,7 +51,6 @@ export const createAudio = ({ source, volume, autoPlay, currentTime }) => {
     // "https://res.cloudinary.com/musixdevelop/video/upload/track-audios/DontLetMeDown.mp3"
     // audio.src = '/Ping 2.mp3'
     // audio.src = '/vocals.wav'
-    console.log(source);
     audio.src = source
     audio.currentTime = currentTime || 0
     audio.volume = volume || 1
@@ -177,9 +176,7 @@ export const logMood = () => {
 }
 
 export const getAudio = ({ createOnCall }) => {
-  console.log(createOnCall, audio);
   if (createOnCall && !audio) {
-    console.log('create');
     createAudio()
   }
   return audio

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ import * as THREE from 'three';
 // import { Earthquake } from './passes/Earthquake.js'
 import {
   createAudio,
+  destroyAudio,
   getAudio,
   getFrequenciesByRange,
   getThreshold,
@@ -288,8 +289,9 @@ export default (e) => {
     autoPlay: true,
     // currentTime: 100.2,
   };
-  document.body.onkeyup = (e) => {
-    if (e.code === 'Space') {
+
+  const startAudioHandler = e => {
+    if(e.code === 'Space') {
       const audio = getAudio({ createOnCall: false });
       if (audio.paused !== undefined) {
         if (audio.paused) {
@@ -301,6 +303,8 @@ export default (e) => {
       createAudio(audioTrackInformation);
     }
   };
+
+  document.addEventListener('keyup', startAudioHandler);
 
   const updateClouds = (array, rotation, beatFactor) => {
     array.forEach((cloud) => {
@@ -402,6 +406,8 @@ export default (e) => {
   useCleanup(() => {
     // composer.removePass(finalPass)
     // composer.removePass(earthquakePass)
+    destroyAudio();
+    document.removeEventListener('keyup', startAudioHandler);
     for (const physicsId of physicsIds) {
       physics.removeGeometry(physicsId);
     }

--- a/index.js
+++ b/index.js
@@ -44,6 +44,12 @@ let cloudMaterial1;
 let cloudMaterial2;
 let cloudMaterial3;
 let cloudMaterial4;
+const localVector3 = new THREE.Vector3();
+const localVector31 = new THREE.Vector3();
+const localColor = new THREE.Color();
+const localColor1 = new THREE.Color();
+const localColor2 = new THREE.Color();
+const localColor3 = new THREE.Color();
 let beatFactor1;
 let beatFactor2;
 let beatFactor3;
@@ -333,14 +339,14 @@ export default (e) => {
         0.3 + moodChanger / 10 + (beatFactor2 ? beatFactor2 / 40 : 0),
         Math.abs(0.8 - moodChanger) + (beatFactor1 ? beatFactor1 / 30 : 0),
       ];
-      neonClubCyberLinesMaterial.uniforms.uMood.value = new THREE.Vector3(
-        ...moodChangerColor
+      neonClubCyberLinesMaterial.uniforms.uMood.value = localVector3.fromArray(
+        moodChangerColor
       );
-      neonClubEmissiveMaterial.uniforms.uMood.value = new THREE.Vector3(
-        ...moodChangerColor
+      neonClubEmissiveMaterial.uniforms.uMood.value = localVector31.fromArray(
+        moodChangerColor
       );
       if (beatFactor1) {
-        cloudMaterial1.color = new THREE.Color(
+        localColor.setRGB(
           (moodChangerColor[0] + beatFactor1 / 30) / 5,
           (moodChangerColor[1] + beatFactor1 / 22) / 5,
           (moodChangerColor[2] + beatFactor1 / 30) / 5
@@ -349,27 +355,31 @@ export default (e) => {
         neonClubCyberLinesMaterial.uniforms.uBeat1.value = beatFactor1;
         neonClubCyberLinesMaterial.uniforms.uBeat2.value = beatFactor3;
         sphere.material.uniforms.uBeat.value = beatFactor3;
+        // cloudMaterial1.color = localColor;
       }
       if (beatFactor2) {
-        cloudMaterial2.color = new THREE.Color(
+        localColor1.setRGB(
           (moodChangerColor[1] + beatFactor2 / 22) / 5,
           (moodChangerColor[0] + beatFactor2 / 30) / 5,
           (moodChangerColor[2] + beatFactor2 / 30) / 5
         );
+        // cloudMaterial2.color = localColor1;
       }
       if (beatFactor3) {
-        cloudMaterial3.color = new THREE.Color(
+        localColor2.setRGB(
           (moodChangerColor[0] - beatFactor3 / 30) / 5,
           (moodChangerColor[1] + beatFactor3 / 25) / 5,
           (moodChangerColor[2] + beatFactor3 / 30) / 5
         );
+        // cloudMaterial3.color = localColor2;
       }
       if (beatFactor4) {
-        cloudMaterial4.color = new THREE.Color(
+        localColor3.setRGB(
           (moodChangerColor[0] - beatFactor4 / 30) / 5,
           (moodChangerColor[1] + beatFactor4 / 24) / 5,
           (moodChangerColor[2] + beatFactor4 / 32) / 5
         );
+        // cloudMaterial4.color = localColor3;
       }
     }
     // shaking the scene with beat


### PR DESCRIPTION
-Fix for https://github.com/webaverse/app/issues/3570
-Created handlers to destroy the Audio object and AudioContext, removing event listeners on cleanup.
-Optimization: Using locals instead of allocations in frame loop